### PR TITLE
Update Internal Tools title color to white

### DIFF
--- a/bsft-dashboard-powerpack-0.0.7/style.css
+++ b/bsft-dashboard-powerpack-0.0.7/style.css
@@ -15,3 +15,7 @@
     font-family: proxima-nova,sans-serif;
     box-shadow: 2px 2px;
 }
+
+.IndexPage-title {
+    color: #FFFFFF;
+}


### PR DESCRIPTION
## Summary
- Updated the color of the "Internal Tools" title to white (#FFFFFF) for better visibility

## Changes
- Added CSS rule for `.IndexPage-title` class in `style.css` to set color to white

🤖 Generated with [Claude Code](https://claude.ai/code)